### PR TITLE
fix a mix use of tensor( size 64x1 ) and tensor( size 64 )

### DIFF
--- a/GAN/conditional_gan/cgan_pytorch.py
+++ b/GAN/conditional_gan/cgan_pytorch.py
@@ -76,8 +76,8 @@ def reset_grad():
 G_solver = optim.Adam(G_params, lr=1e-3)
 D_solver = optim.Adam(D_params, lr=1e-3)
 
-ones_label = Variable(torch.ones(mb_size))
-zeros_label = Variable(torch.zeros(mb_size))
+ones_label = Variable(torch.ones(mb_size, 1))
+zeros_label = Variable(torch.zeros(mb_size, 1))
 
 
 for it in range(100000):

--- a/GAN/vanilla_gan/gan_pytorch.py
+++ b/GAN/vanilla_gan/gan_pytorch.py
@@ -74,8 +74,8 @@ def reset_grad():
 G_solver = optim.Adam(G_params, lr=1e-3)
 D_solver = optim.Adam(D_params, lr=1e-3)
 
-ones_label = Variable(torch.ones(mb_size))
-zeros_label = Variable(torch.zeros(mb_size))
+ones_label = Variable(torch.ones(mb_size, 1))
+zeros_label = Variable(torch.zeros(mb_size, 1))
 
 
 for it in range(100000):


### PR DESCRIPTION
fix a mix use of tensor( size 64x1 ) and tensor( size 64 ) which results:
UserWarning: Using a target size (torch.Size([64])) that is different to the input size (torch.Size([64, 1])) is deprecated. Please ensure they have the same size.