### PR TITLE
Retain variables deprecated

### DIFF
--- a/GAN/dual_gan/dualgan_pytorch.py
+++ b/GAN/dual_gan/dualgan_pytorch.py
@@ -101,7 +101,7 @@ for it in range(1000000):
 
         D1_loss = -(torch.mean(D1_real) - torch.mean(D1_fake))
 
-        D1_loss.backward(retain_variables=True)
+        D1_loss.backward(retain_graph=True)
         D1_solver.step()
 
         # Weight clipping

--- a/GAN/gibbsnet/gibbsnet_pytorch.py
+++ b/GAN/gibbsnet/gibbsnet_pytorch.py
@@ -85,7 +85,7 @@ for it in range(1000000):
 
     D_loss = -torch.mean(log(p_data) + log(1 - p_model))
 
-    D_loss.backward(retain_variables=True)
+    D_loss.backward(retain_graph=True)
     D_solver.step()
     G_solver.step()
     reset_grad()

--- a/GAN/softmax_gan/softmax_gan_pytorch.py
+++ b/GAN/softmax_gan/softmax_gan_pytorch.py
@@ -68,7 +68,7 @@ for it in range(1000000):
     # Dicriminator
     D_loss = torch.sum(D_target * D_real) + log(Z)
 
-    D_loss.backward(retain_variables=True)
+    D_loss.backward(retain_graph=True)
     D_solver.step()
     reset_grad()
 


### PR DESCRIPTION
I test all the pytorch scripts, there are three pytorch scripts (gibbsnet, dual_gan, softmax_gan) results: UserWarning: retain_variables option is deprecated.
